### PR TITLE
Feature: Handle Paired Device Retrieval

### DIFF
--- a/android/src/main/java/com/rnserialbluetoothclassic/domain/BluetoothEvents.kt
+++ b/android/src/main/java/com/rnserialbluetoothclassic/domain/BluetoothEvents.kt
@@ -4,4 +4,5 @@ object EventNames {
   const val BLUETOOTH_STATE_CHANGED = "BluetoothStateChanged"
   const val ON_DISCOVERY_DEVICE = "OnDiscoveryDevice"
   const val ON_DISCOVERY_FINISHED = "OnDiscoveryFinished"
+  const val ON_BONDED_DEVICE = "OnBondedDevice"
 }

--- a/android/src/main/java/com/rnserialbluetoothclassic/receivers/BondStateChangedReceiver.kt
+++ b/android/src/main/java/com/rnserialbluetoothclassic/receivers/BondStateChangedReceiver.kt
@@ -1,0 +1,47 @@
+package com.rnserialbluetoothclassic.receivers
+
+import android.bluetooth.BluetoothDevice
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+
+class BondStateChangedReceiver(private val listener: BluetoothBondChangedListener) : BroadcastReceiver() {
+
+  interface BluetoothBondChangedListener {
+    fun onBluetoothBondChanged(bluetoothDevice: BluetoothDevice?)
+  }
+
+  override fun onReceive(context: Context, intent: Intent) {
+    if (intent.action == FILTER_ACTION_BOND_STATE_CHANGED) {
+      val state = intent.getIntExtra(BluetoothDevice.EXTRA_BOND_STATE, BluetoothDevice.ERROR)
+      val previousBondState = intent.getIntExtra(BluetoothDevice.EXTRA_PREVIOUS_BOND_STATE, BluetoothDevice.ERROR)
+      val bluetoothDevice: BluetoothDevice? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice::class.java)
+      } else {
+        intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE)
+      }
+
+      Log.d("PairDevice", "state ${state}")
+
+
+      when(state) {
+        BluetoothDevice.BOND_BONDED -> {
+          listener.onBluetoothBondChanged(bluetoothDevice)
+          context.unregisterReceiver(this)
+          Log.d("PairDevice", "BOND_BONDED:: Unregister receiver")
+        }
+        BluetoothDevice.BOND_NONE -> {
+          listener.onBluetoothBondChanged(null)
+          context.unregisterReceiver(this)
+          Log.d("PairDevice", "BOND_NONE:: Unregister receiver")
+        }
+      }
+    }
+  }
+
+  companion object {
+    const val FILTER_ACTION_BOND_STATE_CHANGED = BluetoothDevice.ACTION_BOND_STATE_CHANGED
+  }
+}

--- a/src/NativeRnSerialBluetoothClassic.ts
+++ b/src/NativeRnSerialBluetoothClassic.ts
@@ -57,6 +57,7 @@ export const BluetoothListeners = {
   BLUETOOTH_STATE_CHANGED: 'BluetoothStateChanged',
   ON_DISCOVERY_DEVICE: 'OnDiscoveryDevice',
   ON_DISCOVERY_FINISHED: 'OnDiscoveryFinished',
+  ON_BONDED_DEVICE: 'OnBondedDevice',
 } as const;
 
 export type BluetoothListener =
@@ -74,6 +75,14 @@ export interface Spec extends TurboModule {
   getBondedDevices(): Promise<BluetoothDevice[]>;
 
   startDiscovery(): Promise<void>;
+
+  /**
+   *
+   * @param address The address of the device to pair with.
+   * Subscribe to the `BluetoothListeners.ON_BONDED_DEVICE` event to get the result of the pairing.
+   * @returns A promise that resolves when the pairing is complete.
+   */
+  pairDevice(address: string): Promise<void>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,12 @@ export type BluetoothEventPayloads = {
   [BluetoothListeners.BLUETOOTH_STATE_CHANGED]: BluetoothStateChanged;
   [BluetoothListeners.ON_DISCOVERY_DEVICE]: BluetoothDevice;
   [BluetoothListeners.ON_DISCOVERY_FINISHED]: void;
+
+  /**
+   * If activity is cancel it will return null.
+   * If the device is already bonded, it will return the device.
+   */
+  [BluetoothListeners.ON_BONDED_DEVICE]: BluetoothDevice | null;
 };
 
 export const bluetoothListener = new NativeEventEmitter(
@@ -45,4 +51,8 @@ export async function getBondedDevices(): Promise<BluetoothDevice[]> {
 
 export async function startDiscovery(): Promise<void> {
   return await RnSerialBluetoothClassic.startDiscovery();
+}
+
+export async function pairDevice(address: string): Promise<void> {
+  return await RnSerialBluetoothClassic.pairDevice(address);
 }


### PR DESCRIPTION
Added method call to initiate device pairing.

Implemented OnBondedDevice listener to retrieve the bonded device.

- Returns the bonded device if pairing is successful.
- Returns null if pairing fails.